### PR TITLE
Basic implementation of daily stress change for the API, addresses #2

### DIFF
--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/Globals.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/Globals.lua
@@ -1,17 +1,21 @@
 local Globals = {}
 
+--- This is the real time delta, adding up to 48/s
 Globals.multiplier = 0
 Globals.deltaMinutesPerDay = 0
+--- This is the multiplier adjusted for the day length.
+--- Note that this is NOT centered around 1 hour days, but 30 minute days. This means that the default is half the multiplier.
 Globals.delta = 0
 Globals.statsDecreaseMultiplier = 1
+Globals.gameWorldSecondsSinceLastUpdate = 0
 
 -- EvenPaused because it fires before player stat calculations, OnTick fires after
 -- unfortunately, GameTime updates after this, so we're technically always a frame behind, but it doesn't really matter
 Events.OnTickEvenPaused.Add(function()
     Globals.multiplier = Globals.gameTime:getMultiplier()
-    Globals.deltaMinutesPerDay = Globals.gameTime:getDeltaMinutesPerDay()
     Globals.delta = Globals.multiplier * Globals.deltaMinutesPerDay
     Globals.statsDecreaseMultiplier = Globals.sandboxOptions:getStatsDecreaseMultiplier()
+    Globals.gameWorldSecondsSinceLastUpdate = Globals.gameTime:getGameWorldSecondsSinceLastUpdate()
 end)
 
 
@@ -21,6 +25,7 @@ end)
 
 Events.OnGameTimeLoaded.Add(function()
     Globals.gameTime = getGameTime()
+    Globals.deltaMinutesPerDay = Globals.gameTime:getDeltaMinutesPerDay()
 end)
 
 return Globals

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -117,6 +117,18 @@ StatsAPI.setStressFromInfection = function(infectionStress)
     StatsAPI.Stress.infectionStress = infectionStress
 end
 
+---Adds a constant change to stress, the cause being whichever the mod maker wishes
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount of change in stat
+StatsAPI.AddDailyStressChange = function(sourceName, dailyChange)
+    StatsAPI.Stress.dailyChanges[sourceName] = dailyChange/100
+end
+---Adds a constant change to stress, the cause being whichever the mod maker wishes
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount of change in stat
+StatsAPI.RemoveDailyStressChange = function(sourceName)
+    StatsAPI.Stress.dailyChanges[sourceName] = nil
+end
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()
     Vanilla.wantVanilla = false

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -105,6 +105,7 @@ StatsAPI.addTraitPanicModifier = function(trait, modifier)
     StatsAPI.Panic.traitMultipliers[trait] = modifier
 end
 
+
 ---Toggles whether being injured causes characters to gain stress.
 ---@param injuryStress boolean Should injuries cause stress?
 StatsAPI.setStressFromInjuries = function(injuryStress)
@@ -117,18 +118,27 @@ StatsAPI.setStressFromInfection = function(infectionStress)
     StatsAPI.Stress.infectionStress = infectionStress
 end
 
+---Adds a constant change to stress
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount the stat should change by over a day
+StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Stress.modChanges[sourceName] = dailyChange / 86400 / 100
+end
+
+---Adds a constant change to stress
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange number The percent amount the stat should change by over an hour
+StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
+end
+
 ---Adds a constant change to stress, the cause being whichever the mod maker wishes
 ---@param sourceName string The name of the stress source for later identification
----@param dailyChange number The percent amount of change in stat
-StatsAPI.AddDailyStressChange = function(sourceName, dailyChange)
-    StatsAPI.Stress.dailyChanges[sourceName] = dailyChange/100
+StatsAPI.removeStressChange = function(sourceName)
+    StatsAPI.Stress.modChanges[sourceName] = nil
 end
----Adds a constant change to stress, the cause being whichever the mod maker wishes
----@param sourceName string The name of the stress source for later identification
----@param dailyChange number The percent amount of change in stat
-StatsAPI.RemoveDailyStressChange = function(sourceName)
-    StatsAPI.Stress.dailyChanges[sourceName] = nil
-end
+
+
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()
     Vanilla.wantVanilla = false

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -1,7 +1,6 @@
 local Math = require "StatsAPI/lib/Math"
 local Globals = require "StatsAPI/Globals"
 local StatsData = require "StatsAPI/StatsData"
-local Vanilla = require "StatsAPI/vanilla/VanillaTraits"
 
 local StatsAPI = {}
 StatsAPI.Fatigue = require "StatsAPI/stats/Fatigue"
@@ -141,6 +140,7 @@ end
 
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()
+    local Vanilla = require "StatsAPI/vanilla/VanillaTraits"
     Vanilla.wantVanilla = false
 end
 

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
@@ -6,6 +6,7 @@ local Stress = {}
 Stress.injuryStress = true
 Stress.infectionStress = true
 
+Stress.dailyChanges = {}
 ---@type WorldSoundManager
 local worldSoundManager
 Events.OnGameStart.Add(function()
@@ -41,7 +42,14 @@ Stress.getTraitStress = function(character)
     end
     return stressChange
 end
-
+---@param character IsoGameCharacter
+Stress.getDailyStressChange = function()
+    local stressChange = 0
+    for dailyDelta in Stress.dailyDeltas do
+        stressChange = stressChange + dailyDelta * Globals.deltaMinutesPerDay
+    end
+    return stressChange
+end
 ---@param character IsoPlayer
 ---@param stats Stats
 ---@param asleep boolean
@@ -50,7 +58,7 @@ Stress.updateStress = function(character, stats, asleep)
     stress = stress + worldSoundManager:getStressFromSounds(character:getX(), character:getY(), character:getZ()) * ZomboidGlobals.StressFromSoundsMultiplier
     stress = stress + Stress.getHealthStress(character)
     stress = stress + Stress.getTraitStress(character)
-    
+    stress = stress + Stress.getDailyStressChange()
     if not asleep then
         stress = stress - ZomboidGlobals.StressDecrease * Globals.delta
     end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
@@ -6,7 +6,9 @@ local Stress = {}
 Stress.injuryStress = true
 Stress.infectionStress = true
 
-Stress.dailyChanges = {}
+---@type table<string, number>
+Stress.modChanges = {}
+
 ---@type WorldSoundManager
 local worldSoundManager
 Events.OnGameStart.Add(function()
@@ -42,14 +44,15 @@ Stress.getTraitStress = function(character)
     end
     return stressChange
 end
----@param character IsoGameCharacter
-Stress.getDailyStressChange = function()
+
+Stress.getModdedStressChange = function()
     local stressChange = 0
-    for dailyDelta in Stress.dailyDeltas do
-        stressChange = stressChange + dailyDelta * Globals.deltaMinutesPerDay
+    for _, modChange in pairs(Stress.modChanges) do
+        stressChange = stressChange + modChange
     end
-    return stressChange
+    return stressChange * Globals.gameWorldSecondsSinceLastUpdate
 end
+
 ---@param character IsoPlayer
 ---@param stats Stats
 ---@param asleep boolean
@@ -58,7 +61,7 @@ Stress.updateStress = function(character, stats, asleep)
     stress = stress + worldSoundManager:getStressFromSounds(character:getX(), character:getY(), character:getZ()) * ZomboidGlobals.StressFromSoundsMultiplier
     stress = stress + Stress.getHealthStress(character)
     stress = stress + Stress.getTraitStress(character)
-    stress = stress + Stress.getDailyStressChange()
+    stress = stress + Stress.getModdedStressChange()
     if not asleep then
         stress = stress - ZomboidGlobals.StressDecrease * Globals.delta
     end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/vanilla/VanillaTraits.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/vanilla/VanillaTraits.lua
@@ -31,6 +31,6 @@ end
 
 -- Delays the code until the game has reached the main menu. Not strictly necessary, but traits usually aren't created
 -- until then either.
-Events.OnGameBoot.Add(Vanilla.addTraits)
+Events.OnGameBoot.Add(Vanilla.addTraitModifiers)
 
 return Vanilla


### PR DESCRIPTION
I decided to give this a shot, never wrote any kind of an API. This is rather basic, letting you add and remove the custom modifiers to stress. I don't even know if the calculation is correct at the moment.
Perhaps the "add" function should have some extra fields to control the stat change to reduce API calls, for example, if the stat should be altered when the character is asleep.