### PR TITLE
Add Hunger and Thirst to constant modded change

### DIFF
--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -157,6 +157,26 @@ StatsAPI.removeHungerChange = function(sourceName)
     StatsAPI.Hunger.modChanges[sourceName] = nil
 end
 
+---Adds a constant change to fatigue
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount the stat should change by over a day
+StatsAPI.addThirstChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+end
+
+---Same as above, but calculated over an hour for higher precision
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange number The percent amount the stat should change by over an hour
+StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+end
+
+---Removes a previously added change to fatigue
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeThirstChange = function(sourceName)
+    StatsAPI.Thirst.modChanges[sourceName] = nil
+end
+
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()
     local Vanilla = require "StatsAPI/vanilla/VanillaTraits"

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -154,6 +154,26 @@ StatsAPI.removeHungerChange = function(sourceName)
     StatsAPI.Hunger.modChanges[sourceName] = nil
 end
 
+---Adds a constant change to fatigue
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount the stat should change by over a day
+StatsAPI.addThirstChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+end
+
+---Same as above, but calculated over an hour for higher precision
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange number The percent amount the stat should change by over an hour
+StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+end
+
+---Removes a previously added change to fatigue
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeThirstChange = function(sourceName)
+    StatsAPI.Thirst.modChanges[sourceName] = nil
+end
+
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()
     local Vanilla = require "StatsAPI/vanilla/VanillaTraits"

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -114,18 +114,18 @@ StatsAPI.setStressFromInfection = function(infectionStress)
     Stress.infectionStress = infectionStress
 end
 
----Adds a constant change to stress
+---Adds a function that has to return a change in stress, with the value adjusted for daily change
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
-    Stress.modChanges[sourceName] = dailyChange / 86400 / 100
+    Stress.modChanges[sourceName] = {dailyChange,1 / 86400 / 100}
 end
 
----Same as above, but calculated over an hour for higher precision
+---Adds a function that has to return a change in stress, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
-    Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
+    Stress.modChanges[sourceName] = {hourlyChange,1 / 86400 / 100}
 end
 
 ---Removes a previously added change to stress

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -121,19 +121,38 @@ StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
     Stress.modChanges[sourceName] = dailyChange / 86400 / 100
 end
 
----Adds a constant change to stress
+---Same as above, but calculated over an hour for higher precision
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
     Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
 end
 
----Adds a constant change to stress, the cause being whichever the mod maker wishes
+---Removes a previously added change to stress
 ---@param sourceName string The name of the stress source for later identification
 StatsAPI.removeStressChange = function(sourceName)
     Stress.modChanges[sourceName] = nil
 end
 
+---Adds a constant change to hunger
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount the stat should change by over a day
+StatsAPI.addHungerChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+end
+
+---Same as above, but calculated over an hour for higher precision
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange number The percent amount the stat should change by over an hour
+StatsAPI.addHungerChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+end
+
+---Removes a previously added change to hunger
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeHungerChange = function(sourceName)
+    StatsAPI.Hunger.modChanges[sourceName] = nil
+end
 
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -124,19 +124,38 @@ StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
     StatsAPI.Stress.modChanges[sourceName] = dailyChange / 86400 / 100
 end
 
----Adds a constant change to stress
+---Same as above, but calculated over an hour for higher precision
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
     StatsAPI.Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
 end
 
----Adds a constant change to stress, the cause being whichever the mod maker wishes
+---Removes a previously added change to stress
 ---@param sourceName string The name of the stress source for later identification
 StatsAPI.removeStressChange = function(sourceName)
     StatsAPI.Stress.modChanges[sourceName] = nil
 end
 
+---Adds a constant change to hunger
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange number The percent amount the stat should change by over a day
+StatsAPI.addHungerChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+end
+
+---Same as above, but calculated over an hour for higher precision
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange number The percent amount the stat should change by over an hour
+StatsAPI.addHungerChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+end
+
+---Removes a previously added change to hunger
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeHungerChange = function(sourceName)
+    StatsAPI.Hunger.modChanges[sourceName] = nil
+end
 
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.
 StatsAPI.disableVanillaTraits = function()

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -104,7 +104,6 @@ StatsAPI.addTraitPanicModifier = function(trait, modifier)
     StatsAPI.Panic.traitMultipliers[trait] = modifier
 end
 
-
 ---Toggles whether being injured causes characters to gain stress.
 ---@param injuryStress boolean Should injuries cause stress?
 StatsAPI.setStressFromInjuries = function(injuryStress)
@@ -117,18 +116,18 @@ StatsAPI.setStressFromInfection = function(infectionStress)
     StatsAPI.Stress.infectionStress = infectionStress
 end
 
----Adds a function that has to return a change in stress, with the value adjusted for daily change
+---Adds a constant change to stress, with the value set to a percent of the maximum over a day
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Stress.modChanges[sourceName] = {dailyChange,1 / 86400 / 100}
+    StatsAPI.Stress.modChanges[sourceName] = dailyChange / 86400 / 100
 end
 
----Adds a function that has to return a change in stress, with the value adjusted for hourly change
+---Adds a constant change to stress, with the value set to a percent of the maximum over an hour
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Stress.modChanges[sourceName] = {hourlyChange,1 / 86400 / 100}
+    StatsAPI.Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
 end
 
 ---Removes a previously added change to stress
@@ -137,18 +136,18 @@ StatsAPI.removeStressChange = function(sourceName)
     StatsAPI.Stress.modChanges[sourceName] = nil
 end
 
----Adds a function that has to return a change in hunger, with the value adjusted for daily change
+---Adds a constant change to hunger, with the value set to a percent of the maximum over a day
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addHungerChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
+    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400
 end
 
----Adds a function that has to return a change in hunger, with the value adjusted for hourly change
+---Adds a constant change to hunger, with the value set to a percent of the maximum over an hour
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addHungerChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
+    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600
 end
 
 ---Removes a previously added change to hunger
@@ -157,18 +156,78 @@ StatsAPI.removeHungerChange = function(sourceName)
     StatsAPI.Hunger.modChanges[sourceName] = nil
 end
 
----Adds a function that has to return a change in thurst, with the value adjusted for daily change
+---Adds a constant change to thirst, with the value set to a percent of the maximum over a day
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addThirstChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Thirst.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
+    StatsAPI.Thirst.modChanges[sourceName] = dailyChange / 86400
+end
+
+---Adds a constant change to thirst, with the value set to a percent of the maximum over an hour
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange number The percent amount the stat should change by over an hour
+StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Thirst.modChanges[sourceName] = hourlyChange/ 3600
+end
+
+---Removes a previously added change to fatigue
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeThirstChange = function(sourceName)
+    StatsAPI.Thirst.modChanges[sourceName] = nil
+end
+
+---Adds a function that has to return a change in stress, with the value adjusted for daily change
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange function The function that returns a percentage change over a day
+StatsAPI.addStressChangeFunctionDaily = function(sourceName, dailyChange)
+    StatsAPI.Stress.modFunctions[sourceName] = {dailyChange,1 / 86400 / 100}
+end
+
+---Adds a function that has to return a change in stress, with the value adjusted for hourly change
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange function The function that returns a percentage change over an hour
+StatsAPI.addStressChangeFunctionHourly = function(sourceName, hourlyChange)
+    StatsAPI.Stress.modFunctions[sourceName] = {hourlyChange,1 / 3600 / 100}
+end
+
+---Removes a previously added change to stress
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeStressFunctionChange = function(sourceName)
+    StatsAPI.Stress.modFunctions[sourceName] = nil
+end
+
+---Adds a function that has to return a change in hunger, with the value adjusted for daily change
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange function The function that returns a percentage change over a day
+StatsAPI.addHungerFunctionChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Hunger.modFunctions[sourceName] = {dailyChange, 1 / 86400}
+end
+
+---Adds a function that has to return a change in hunger, with the value adjusted for hourly change
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange function The function that returns a percentage change over an hour
+StatsAPI.addHungerFunctionChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Hunger.modFunctions[sourceName] = {hourlyChange, 1/ 3600}
+end
+
+---Removes a previously added change to hunger
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeHungerFunctionChange = function(sourceName)
+    StatsAPI.Hunger.modFunctions[sourceName] = nil
+end
+
+---Adds a function that has to return a change in thurst, with the value adjusted for daily change
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange function The function that returns a percentage change over a day
+StatsAPI.addThirstFunctionChangeDaily = function(sourceName, dailyChange)
+    StatsAPI.Thirst.modFunctions[sourceName] = {dailyChange, 1 / 86400}
 end
 
 ---Adds a function that has to return a change in thirst, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
----@param hourlyChange number The percent amount the stat should change by over an hour
-StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Thirst.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
+---@param hourlyChange function The function that returns a percentage change over an hour
+StatsAPI.addThirstFunctionChangeHourly = function(sourceName, hourlyChange)
+    StatsAPI.Thirst.modFunctions[sourceName] = {hourlyChange, 1/ 3600}
 end
 
 ---Removes a previously added change to fatigue

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -137,18 +137,18 @@ StatsAPI.removeStressChange = function(sourceName)
     StatsAPI.Stress.modChanges[sourceName] = nil
 end
 
----Adds a constant change to hunger
+---Adds a function that has to return a change in hunger, with the value adjusted for daily change
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addHungerChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+    StatsAPI.Hunger.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
 end
 
----Same as above, but calculated over an hour for higher precision
+---Adds a function that has to return a change in hunger, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addHungerChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+    StatsAPI.Hunger.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
 end
 
 ---Removes a previously added change to hunger
@@ -157,18 +157,18 @@ StatsAPI.removeHungerChange = function(sourceName)
     StatsAPI.Hunger.modChanges[sourceName] = nil
 end
 
----Adds a constant change to fatigue
+---Adds a function that has to return a change in thurst, with the value adjusted for daily change
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addThirstChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+    StatsAPI.Thirst.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
 end
 
----Same as above, but calculated over an hour for higher precision
+---Adds a function that has to return a change in thirst, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+    StatsAPI.Thirst.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
 end
 
 ---Removes a previously added change to fatigue

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -117,18 +117,18 @@ StatsAPI.setStressFromInfection = function(infectionStress)
     StatsAPI.Stress.infectionStress = infectionStress
 end
 
----Adds a constant change to stress
+---Adds a function that has to return a change in stress, with the value adjusted for daily change
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Stress.modChanges[sourceName] = dailyChange / 86400 / 100
+    StatsAPI.Stress.modChanges[sourceName] = {dailyChange,1 / 86400 / 100}
 end
 
----Same as above, but calculated over an hour for higher precision
+---Adds a function that has to return a change in stress, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
+    StatsAPI.Stress.modChanges[sourceName] = {hourlyChange,1 / 86400 / 100}
 end
 
 ---Removes a previously added change to stress

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -134,18 +134,18 @@ StatsAPI.removeStressChange = function(sourceName)
     Stress.modChanges[sourceName] = nil
 end
 
----Adds a constant change to hunger
+---Adds a function that has to return a change in hunger, with the value adjusted for daily change
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addHungerChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+    StatsAPI.Hunger.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
 end
 
----Same as above, but calculated over an hour for higher precision
+---Adds a function that has to return a change in hunger, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addHungerChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+    StatsAPI.Hunger.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
 end
 
 ---Removes a previously added change to hunger
@@ -154,18 +154,18 @@ StatsAPI.removeHungerChange = function(sourceName)
     StatsAPI.Hunger.modChanges[sourceName] = nil
 end
 
----Adds a constant change to fatigue
+---Adds a function that has to return a change in thurst, with the value adjusted for daily change
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addThirstChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = dailyChange / 86400 / 100
+    StatsAPI.Thirst.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
 end
 
----Same as above, but calculated over an hour for higher precision
+---Adds a function that has to return a change in thirst, with the value adjusted for hourly change
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = hourlyChange / 3600 / 100
+    StatsAPI.Thirst.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
 end
 
 ---Removes a previously added change to fatigue

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/StatsAPI.lua
@@ -101,7 +101,6 @@ StatsAPI.addConstantEffectHours = function(character, stat, amount, duration)
     StatsAPI.addConstantEffect(character, stat, amount / 3600, duration * 3600)
 end
 
-
 ---Toggles whether being injured causes characters to gain stress.
 ---@param injuryStress boolean Should injuries cause stress?
 StatsAPI.setStressFromInjuries = function(injuryStress)
@@ -114,18 +113,18 @@ StatsAPI.setStressFromInfection = function(infectionStress)
     Stress.infectionStress = infectionStress
 end
 
----Adds a function that has to return a change in stress, with the value adjusted for daily change
+---Adds a constant change to stress, with the value set to a percent of the maximum over a day
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addStressChangeDaily = function(sourceName, dailyChange)
-    Stress.modChanges[sourceName] = {dailyChange,1 / 86400 / 100}
+    Stress.modChanges[sourceName] = dailyChange / 86400 / 100
 end
 
----Adds a function that has to return a change in stress, with the value adjusted for hourly change
+---Adds a constant change to stress, with the value set to a percent of the maximum over an hour
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addStressChangeHourly = function(sourceName, hourlyChange)
-    Stress.modChanges[sourceName] = {hourlyChange,1 / 86400 / 100}
+    Stress.modChanges[sourceName] = hourlyChange / 3600 / 100
 end
 
 ---Removes a previously added change to stress
@@ -134,44 +133,104 @@ StatsAPI.removeStressChange = function(sourceName)
     Stress.modChanges[sourceName] = nil
 end
 
----Adds a function that has to return a change in hunger, with the value adjusted for daily change
+---Adds a constant change to hunger, with the value set to a percent of the maximum over a day
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addHungerChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
+    Hunger.modChanges[sourceName] = dailyChange / 86400
 end
 
----Adds a function that has to return a change in hunger, with the value adjusted for hourly change
+---Adds a constant change to hunger, with the value set to a percent of the maximum over an hour
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addHungerChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Hunger.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
+    Hunger.modChanges[sourceName] = hourlyChange / 3600
 end
 
 ---Removes a previously added change to hunger
 ---@param sourceName string The name of the stress source for later identification
 StatsAPI.removeHungerChange = function(sourceName)
-    StatsAPI.Hunger.modChanges[sourceName] = nil
+    Hunger.modChanges[sourceName] = nil
 end
 
----Adds a function that has to return a change in thurst, with the value adjusted for daily change
+---Adds a constant change to thirst, with the value set to a percent of the maximum over a day
 ---@param sourceName string The name of the stress source for later identification
 ---@param dailyChange number The percent amount the stat should change by over a day
 StatsAPI.addThirstChangeDaily = function(sourceName, dailyChange)
-    StatsAPI.Thirst.modChanges[sourceName] = {dailyChange, 1 / 86400 / 100}
+    Thirst.modChanges[sourceName] = dailyChange / 86400
 end
 
----Adds a function that has to return a change in thirst, with the value adjusted for hourly change
+---Adds a constant change to thirst, with the value set to a percent of the maximum over an hour
 ---@param sourceName string The name of the stress source for later identification
 ---@param hourlyChange number The percent amount the stat should change by over an hour
 StatsAPI.addThirstChangeHourly = function(sourceName, hourlyChange)
-    StatsAPI.Thirst.modChanges[sourceName] = {hourlyChange, 1/ 3600 / 100}
+    Thirst.modChanges[sourceName] = hourlyChange/ 3600
 end
 
 ---Removes a previously added change to fatigue
 ---@param sourceName string The name of the stress source for later identification
 StatsAPI.removeThirstChange = function(sourceName)
-    StatsAPI.Thirst.modChanges[sourceName] = nil
+    Thirst.modChanges[sourceName] = nil
+end
+
+---Adds a function that has to return a change in stress, with the value adjusted for daily change
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange function The function that returns a percentage change over a day
+StatsAPI.addStressChangeFunctionDaily = function(sourceName, dailyChange)
+    Stress.modFunctions[sourceName] = {dailyChange,1 / 86400 / 100}
+end
+
+---Adds a function that has to return a change in stress, with the value adjusted for hourly change
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange function The function that returns a percentage change over an hour
+StatsAPI.addStressChangeFunctionHourly = function(sourceName, hourlyChange)
+    Stress.modFunctions[sourceName] = {hourlyChange,1 / 3600 / 100}
+end
+
+---Removes a previously added change to stress
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeStressFunctionChange = function(sourceName)
+    Stress.modFunctions[sourceName] = nil
+end
+
+---Adds a function that has to return a change in hunger, with the value adjusted for daily change
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange function The function that returns a percentage change over a day
+StatsAPI.addHungerFunctionChangeDaily = function(sourceName, dailyChange)
+    Hunger.modFunctions[sourceName] = {dailyChange, 1 / 86400}
+end
+
+---Adds a function that has to return a change in hunger, with the value adjusted for hourly change
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange function The function that returns a percentage change over an hour
+StatsAPI.addHungerFunctionChangeHourly = function(sourceName, hourlyChange)
+    Hunger.modFunctions[sourceName] = {hourlyChange, 1/ 3600}
+end
+
+---Removes a previously added change to hunger
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeHungerFunctionChange = function(sourceName)
+    Hunger.modFunctions[sourceName] = nil
+end
+
+---Adds a function that has to return a change in thurst, with the value adjusted for daily change
+---@param sourceName string The name of the stress source for later identification
+---@param dailyChange function The function that returns a percentage change over a day
+StatsAPI.addThirstFunctionChangeDaily = function(sourceName, dailyChange)
+    Thirst.modFunctions[sourceName] = {dailyChange, 1 / 86400}
+end
+
+---Adds a function that has to return a change in thirst, with the value adjusted for hourly change
+---@param sourceName string The name of the stress source for later identification
+---@param hourlyChange function The function that returns a percentage change over an hour
+StatsAPI.addThirstFunctionChangeHourly = function(sourceName, hourlyChange)
+    Thirst.modFunctions[sourceName] = {hourlyChange, 1/ 3600}
+end
+
+---Removes a previously added change to fatigue
+---@param sourceName string The name of the stress source for later identification
+StatsAPI.removeThirstChange = function(sourceName)
+    Thirst.modChanges[sourceName] = nil
 end
 
 ---Prevents the vanilla trait effects from being added. Must be called before OnGameBoot or it will have no effect.

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
@@ -62,8 +62,8 @@ Hunger.updateHunger = function(character, stats, asleep)
             hungerChange = hungerChange * ZomboidGlobals.HungerIncreaseWhenWellFed * Globals.statsDecreaseMultiplier
         end
     end
-    --- TODO Consider if the API should handle some conditions like moving or sleeping for modded changes, or whether that
-    --- should fall on the API users to manage
+    -- TODO Consider if the API should handle some conditions like moving or sleeping for modded changes, or whether that
+    -- should fall on the API users to manage
     hungerChange = hungerChange + Hunger.getModdedHungerChange() * appetiteMultiplier *  Globals.statsDecreaseMultiplier
     stats:setHunger(Math.min(stats:getHunger() + hungerChange, 1))
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
@@ -4,13 +4,14 @@ local Globals = require "StatsAPI/Globals"
 local Hunger = {}
 Hunger.appetiteMultipliers = {}
 
----@type table<string, number>
+---@type table<string, table<function,number>>
 Hunger.modChanges = {}
 
-Hunger.getModdedHungerChange = function()
+---@param data StatsData
+Hunger.getModdedHungerChange = function(data)
     local hungerChange = 0
     for _, modChange in pairs(Hunger.modChanges) do
-        hungerChange = hungerChange + modChange
+        hungerChange = hungerChange + modChange[1](data) * modChange[2]
     end
     return hungerChange * Globals.gameWorldSecondsSinceLastUpdate
 end
@@ -62,9 +63,7 @@ Hunger.updateHunger = function(character, stats, asleep)
             hungerChange = hungerChange * ZomboidGlobals.HungerIncreaseWhenWellFed * Globals.statsDecreaseMultiplier
         end
     end
-    -- TODO Consider if the API should handle some conditions like moving or sleeping for modded changes, or whether that
-    -- should fall on the API users to manage
-    hungerChange = hungerChange + Hunger.getModdedHungerChange() * appetiteMultiplier *  Globals.statsDecreaseMultiplier
+    hungerChange = hungerChange + Hunger.getModdedHungerChange() * appetiteMultiplier
     stats:setHunger(Math.min(stats:getHunger() + hungerChange, 1))
 end
 

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
@@ -4,6 +4,17 @@ local Globals = require "StatsAPI/Globals"
 local Hunger = {}
 Hunger.appetiteMultipliers = {}
 
+---@type table<string, number>
+Hunger.modChanges = {}
+
+Hunger.getModdedHungerChange = function()
+    local hungerChange = 0
+    for _, modChange in pairs(Hunger.modChanges) do
+        hungerChange = hungerChange + modChange
+    end
+    return hungerChange * Globals.gameWorldSecondsSinceLastUpdate
+end
+
 ---@param character IsoGameCharacter
 ---@return number
 Hunger.getAppetiteMultiplier = function(character)
@@ -46,7 +57,9 @@ Hunger.updateHunger = function(self)
             hungerChange = hungerChange * ZomboidGlobals.HungerIncreaseWhenWellFed * Globals.statsDecreaseMultiplier
         end
     end
-    
+    --- TODO: Consider if the API should handle some conditions like moving or sleeping for modded changes, or whether that
+    --- should fall on the API users to manage
+    hungerChange = hungerChange + Hunger.getModdedHungerChange() * appetiteMultiplier *  Globals.statsDecreaseMultiplier
     self.stats.hunger = self.stats.hunger + hungerChange
 end
 

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
@@ -4,6 +4,17 @@ local Globals = require "StatsAPI/Globals"
 local Hunger = {}
 Hunger.appetiteMultipliers = {}
 
+---@type table<string, number>
+Hunger.modChanges = {}
+
+Hunger.getModdedHungerChange = function()
+    local hungerChange = 0
+    for _, modChange in pairs(Hunger.modChanges) do
+        hungerChange = hungerChange + modChange
+    end
+    return hungerChange * Globals.gameWorldSecondsSinceLastUpdate
+end
+
 ---@param character IsoGameCharacter
 ---@param stats Stats|nil
 ---@return number
@@ -51,7 +62,9 @@ Hunger.updateHunger = function(character, stats, asleep)
             hungerChange = hungerChange * ZomboidGlobals.HungerIncreaseWhenWellFed * Globals.statsDecreaseMultiplier
         end
     end
-    
+    --- TODO Consider if the API should handle some conditions like moving or sleeping for modded changes, or whether that
+    --- should fall on the API users to manage
+    hungerChange = hungerChange + Hunger.getModdedHungerChange() * appetiteMultiplier *  Globals.statsDecreaseMultiplier
     stats:setHunger(Math.min(stats:getHunger() + hungerChange, 1))
 end
 

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
@@ -4,13 +4,14 @@ local Globals = require "StatsAPI/Globals"
 local Hunger = {}
 Hunger.appetiteMultipliers = {}
 
----@type table<string, number>
+---@type table<string, table<function,number>>
 Hunger.modChanges = {}
 
-Hunger.getModdedHungerChange = function()
+---@param data StatsData
+Hunger.getModdedHungerChange = function(data)
     local hungerChange = 0
     for _, modChange in pairs(Hunger.modChanges) do
-        hungerChange = hungerChange + modChange
+        hungerChange = hungerChange + modChange[1](data) * modChange[2]
     end
     return hungerChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Hunger.lua
@@ -4,14 +4,20 @@ local Globals = require "StatsAPI/Globals"
 local Hunger = {}
 Hunger.appetiteMultipliers = {}
 
----@type table<string, table<function,number>>
+
+---@type table<string, number>
 Hunger.modChanges = {}
+---@type table<string, table<function,number>>
+Hunger.modFunctions = {}
 
 ---@param data StatsData
 Hunger.getModdedHungerChange = function(data)
     local hungerChange = 0
+    for _, modFunction in pairs(Hunger.modFunctions) do
+        hungerChange = hungerChange + modFunction[1](data) * modFunction[2]
+    end
     for _, modChange in pairs(Hunger.modChanges) do
-        hungerChange = hungerChange + modChange[1](data) * modChange[2]
+        hungerChange = hungerChange + modChange
     end
     return hungerChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
@@ -5,9 +5,10 @@ local Stress = {}
 
 Stress.injuryStress = true
 Stress.infectionStress = true
-
----@type table<string, table<function,number>>
+---@type table<string, number>
 Stress.modChanges = {}
+---@type table<string, table<function,number>>
+Stress.modFunctions = {}
 
 ---@type WorldSoundManager
 local worldSoundManager
@@ -48,8 +49,11 @@ end
 ---@param data StatsData
 Stress.getModdedStressChange = function(data)
     local stressChange = 0
+    for _, modFunction in pairs(Stress.modFunctions) do
+        stressChange = stressChange + modFunction[1](data) * modFunction[2]
+    end
     for _, modChange in pairs(Stress.modChanges) do
-        stressChange = stressChange + modChange[1](data) * modChange[2]
+        stressChange = stressChange + modChange
     end
     return stressChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
@@ -6,7 +6,7 @@ local Stress = {}
 Stress.injuryStress = true
 Stress.infectionStress = true
 
----@type table<string, number>
+---@type table<string, table<function,number>>
 Stress.modChanges = {}
 
 ---@type WorldSoundManager
@@ -44,11 +44,11 @@ Stress.getTraitStress = function(character)
     end
     return stressChange
 end
-
-Stress.getModdedStressChange = function()
+---@param data StatsData
+Stress.getModdedStressChange = function(data)
     local stressChange = 0
     for _, modChange in pairs(Stress.modChanges) do
-        stressChange = stressChange + modChange
+        stressChange = stressChange + modChange[1](data) * modChange[2]
     end
     return stressChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
@@ -6,7 +6,7 @@ local Stress = {}
 Stress.injuryStress = true
 Stress.infectionStress = true
 
----@type table<string, number>
+---@type table<string, table<function,number>>
 Stress.modChanges = {}
 
 ---@type WorldSoundManager
@@ -45,11 +45,11 @@ Stress.getTraitStress = function(character)
     -- TODO: handle cigarette stress here
     return stressChange
 end
-
-Stress.getModdedStressChange = function()
+---@param data StatsData
+Stress.getModdedStressChange = function(data)
     local stressChange = 0
     for _, modChange in pairs(Stress.modChanges) do
-        stressChange = stressChange + modChange
+        stressChange = stressChange + modChange[1](data) * modChange[2]
     end
     return stressChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Stress.lua
@@ -5,9 +5,10 @@ local Stress = {}
 
 Stress.injuryStress = true
 Stress.infectionStress = true
-
----@type table<string, table<function,number>>
+---@type table<string, number>
 Stress.modChanges = {}
+---@type table<string, table<function,number>>
+Stress.modFunctions = {}
 
 ---@type WorldSoundManager
 local worldSoundManager
@@ -47,8 +48,11 @@ end
 ---@param data StatsData
 Stress.getModdedStressChange = function(data)
     local stressChange = 0
+    for _, modFunction in pairs(Stress.modFunctions) do
+        stressChange = stressChange + modFunction[1](data) * modFunction[2]
+    end
     for _, modChange in pairs(Stress.modChanges) do
-        stressChange = stressChange + modChange[1](data) * modChange[2]
+        stressChange = stressChange + modChange
     end
     return stressChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
@@ -4,6 +4,17 @@ local Globals = require "StatsAPI/Globals"
 local Thirst = {}
 Thirst.thirstMultipliers = {}
 
+---@type table<string, number>
+Thirst.modChanges = {}
+
+Thirst.getModdedThirstChange = function()
+    local thirstChange = 0
+    for _, modChange in pairs(Thirst.modChanges) do
+        thirstChange = thirstChange + modChange
+    end
+    return thirstChange * Globals.gameWorldSecondsSinceLastUpdate
+end
+
 ---@param character IsoGameCharacter
 Thirst.getThirstMultiplier = function(character)
     local thirstMultiplier = 1
@@ -31,6 +42,8 @@ Thirst.updateThirst = function(character, stats, asleep)
         else
             thirst = thirst + ZomboidGlobals.ThirstSleepingIncrease * thirstMultiplier
         end
+        --- I don't know what remains of thirst after these multipliers
+        thirst = thirst + Thirst.getModdedThirstChange() * ZomboidGlobals.ThirstIncrease * character:getThirstMultiplier() * thirstMultiplier
         stats:setThirst(Math.min(thirst, 1))
     end
     character:autoDrink()

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
@@ -4,14 +4,19 @@ local Globals = require "StatsAPI/Globals"
 local Thirst = {}
 Thirst.thirstMultipliers = {}
 
----@type table<string, table<function,number>>
+---@type table<string, number>
 Thirst.modChanges = {}
+---@type table<string, table<function,number>>
+Thirst.modFunctions = {}
 
 ---@param data StatsData
 Thirst.getModdedThirstChange = function(data)
     local thirstChange = 0
-    for _, modChange in pairs(Thirst.modChanges) do
+    for _, modChange in pairs(Thirst.modFunctions) do
         thirstChange = thirstChange + modChange[1](data) * modChange[2]
+    end
+    for _, modChange in pairs(Thirst.modChanges) do
+        thirstChange = thirstChange + modChange
     end
     return thirstChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
@@ -4,13 +4,14 @@ local Globals = require "StatsAPI/Globals"
 local Thirst = {}
 Thirst.thirstMultipliers = {}
 
----@type table<string, number>
+---@type table<string, table<function,number>>
 Thirst.modChanges = {}
 
-Thirst.getModdedThirstChange = function()
+---@param data StatsData
+Thirst.getModdedThirstChange = function(data)
     local thirstChange = 0
     for _, modChange in pairs(Thirst.modChanges) do
-        thirstChange = thirstChange + modChange
+        thirstChange = thirstChange + modChange[1](data) * modChange[2]
     end
     return thirstChange * Globals.gameWorldSecondsSinceLastUpdate
 end

--- a/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
+++ b/Contents/mods/StatsAPI/media/lua/client/StatsAPI/stats/Thirst.lua
@@ -4,6 +4,17 @@ local Globals = require "StatsAPI/Globals"
 local Thirst = {}
 Thirst.thirstMultipliers = {}
 
+---@type table<string, number>
+Thirst.modChanges = {}
+
+Thirst.getModdedThirstChange = function()
+    local thirstChange = 0
+    for _, modChange in pairs(Thirst.modChanges) do
+        thirstChange = thirstChange + modChange
+    end
+    return thirstChange * Globals.gameWorldSecondsSinceLastUpdate
+end
+
 ---@param character IsoGameCharacter
 Thirst.getThirstMultiplier = function(character)
     local thirstMultiplier = 1
@@ -29,6 +40,7 @@ Thirst.updateThirst = function(self)
         else
             self.stats.thirst = self.stats.thirst + ZomboidGlobals.ThirstSleepingIncrease * thirstMultiplier
         end
+        self.stats.thirst = self.stats.thirst + Thirst.getModdedThirstChange() * self.character:getThirstMultiplier() * thirstMultiplier
     end
     self.character:autoDrink()
 end


### PR DESCRIPTION
I added Hunger and Thirst based on the implementation in stress. I am uncertain how to implement it for panic, sleep and fatigue, due to those stats being adjusted in a different way(as they both increase and decrease separately, instead of being concatenated like stress). Perhaps having different tables for a constant increase and a constant decrease. 